### PR TITLE
chore: revert poetry workflow to ubuntu-22.04 runners 

### DIFF
--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -18,7 +18,7 @@ on:
       runner:
         required: false
         type: string
-        default: ubuntu-24.04
+        default: ubuntu-22.04
         description: GitHub runner for the job
 
       poetry_scripts:


### PR DESCRIPTION
Until we solve python-cdk image issues with setup-python action.
<img width="1738" alt="image" src="https://github.com/user-attachments/assets/509394af-af3c-4662-b80b-034f5a7e14bd" />
https://github.com/smg-real-estate/ml-data-services-hub/actions/runs/12656249791/job/35269488158