### PR TITLE
feat: run git status on failure

### DIFF
--- a/.github/workflows/poetry.yml
+++ b/.github/workflows/poetry.yml
@@ -188,6 +188,9 @@ jobs:
         if: failure()
         run: |
           set -v \
+          && echo "============ Git status: ===========" \
+          && git status \
+          && echo "====================================" \
           && (printenv | sort )\
           && id \
           && pwd \


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/poetry.yml` file. The change adds commands to print the Git status during the failure step of the workflow.

* [`.github/workflows/poetry.yml`](diffhunk://#diff-7be3385942a248b00e58c09855afc13a56eb06ffde78b9c83213a80082043de9R191-R193): Added commands to print the Git status for better debugging information in case of failure.