### PR TITLE
feat: cache poetry installation via pipx

### DIFF
--- a/.github/workflows/poetry-blacksmith.yml
+++ b/.github/workflows/poetry-blacksmith.yml
@@ -78,6 +78,14 @@ jobs:
 
       - run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
+      - name: Cache pipx
+        uses: useblacksmith/cache@v5
+        with:
+          path: |
+            /opt/pipx
+            /opt/pipx_bin
+          key: ${{runner.os}}-${{runner.arch}}-poetry
+
       - name: Install Poetry
         run: pipx install poetry
 
@@ -149,7 +157,7 @@ jobs:
         uses: useblacksmith/cache@v5
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: ${{runner.os}}-${{runner.arch}}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - uses: actions/github-script@v7
         name: run-scripts


### PR DESCRIPTION
This pull request updates the `.github/workflows/poetry-blacksmith.yml` file to improve caching mechanisms for dependencies and tools, optimizing workflow performance. The most important changes include adding a cache step for `pipx` and modifying the cache key for pre-commit hooks to include runner-specific details.

### Workflow caching improvements:

* Added a new caching step for `pipx` using the `useblacksmith/cache@v5` action. This caches the `pipx` and `pipx_bin` directories to improve dependency installation efficiency.
* Updated the cache key for pre-commit hooks to include the runner's operating system and architecture, ensuring cache consistency across different environments.